### PR TITLE
Improve interaction with TypeDB cluster databases 

### DIFF
--- a/common/exception/TypeDBClientException.java
+++ b/common/exception/TypeDBClientException.java
@@ -49,13 +49,11 @@ public class TypeDBClientException extends RuntimeException {
 
     public TypeDBClientException(ErrorMessage error, Object... parameters) {
         super(error.message(parameters));
-        assert !getMessage().contains("%s");
         this.errorMessage = error;
     }
 
     public TypeDBClientException(Throwable cause, ErrorMessage error, Object... parameters) {
         super(error.message(parameters), cause);
-        assert !getMessage().contains("%s");
         this.errorMessage = error;
     }
 

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -53,7 +53,7 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/vaticle/typedb-behaviour",
-        commit = "90b4addcd71a398e9e52e322021c49310e66a47a" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "73fc133d15f32542e34f913bd1fdc97f3697fab4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )
 
 def vaticle_factory_tracing():

--- a/test/integration/ClientEncryptionTest.java
+++ b/test/integration/ClientEncryptionTest.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.vaticle.typedb.client.common.exception.ErrorMessage.Client.CLUSTER_CONNECTION_CLOSED_UKNOWN;
@@ -61,7 +60,6 @@ public class ClientEncryptionTest {
             Map.entry("--server.encryption.private-key", CLUSTER_PRIVATE_KEY.toAbsolutePath().toString()),
             Map.entry("--server.encryption.root-ca", CLUSTER_CA.toAbsolutePath().toString())
     );
-
 
     private static final TypeDBCredential ENCRYPTED_CREDENTIALS = new TypeDBCredential(USERNAME, PASSWORD, CLUSTER_CA);
     private static final TypeDBCredential MISCONFIGURED_CREDENTIALS = new TypeDBCredential(USERNAME, PASSWORD, WRONG_CA);


### PR DESCRIPTION
## What is the goal of this PR?
We refactor the the client's interaction with TypeDB cluster for more clarity. 
We also fix a bug so that opening a session to a non-existent database on TypeDB cluster fails immediately with a "database not found exception" rather than failing after 10 seconds with a connection error.

## What are the changes implemented in this PR?
* Client is now explicitly aware of cluster's response when it has no replicator for a given database.
* Refactors `ClusterDatabaseManager` to runAnyReplica or runPrimaryReplica as required rather than relying on a utility function which always tries to runAnyReplica first, then runsPrimaryReplica if the node throws "Not primary replica"
- fixes vaticle/typedb-cluster#234